### PR TITLE
Initiative numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2613,11 +2613,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
@@ -7590,11 +7585,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "material-colors": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
-    },
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -11153,18 +11143,6 @@
         "whatwg-fetch": "3.0.0"
       }
     },
-    "react-color": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.14.1.tgz",
-      "integrity": "sha512-ssv2ArSZdhTbIs29hyfw8JW+s3G4BCx/ILkwCajWZzrcx/2ZQfRpsaLVt38LAPbxe50LLszlmGtRerA14JzzRw==",
-      "requires": {
-        "lodash": "^4.0.1",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
     "react-dev-utils": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-6.0.4.tgz",
@@ -11268,16 +11246,6 @@
         "schedule": "^0.5.0"
       }
     },
-    "react-drag-list": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-drag-list/-/react-drag-list-1.1.0.tgz",
-      "integrity": "sha512-stV5hWy9ui/0RLdWuSH/q3M11wwWWpLs2lgNMpfVddjCbhXU/1w95h2NMmcsxnSmKZ/WvN1zlbymk/UlT0vP0A==",
-      "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.5",
-        "sortablejs": "^1.5.1"
-      }
-    },
     "react-error-overlay": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.0.4.tgz",
@@ -11335,14 +11303,6 @@
         "webpack-dev-server": "3.1.9",
         "webpack-manifest-plugin": "2.0.4",
         "workbox-webpack-plugin": "3.6.2"
-      }
-    },
-    "reactcss": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "requires": {
-        "lodash": "^4.0.1"
       }
     },
     "read-pkg": {
@@ -12850,11 +12810,6 @@
         }
       }
     },
-    "sortablejs": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.7.0.tgz",
-      "integrity": "sha1-gKKyNwq9Vo4c7IwnETHvMKkE+ig="
-    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -13593,11 +13548,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
-    },
-    "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "lodash": "^4.17.11",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-scripts": "2.0.4"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "lodash": "^4.17.11",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-scripts": "2.0.4"

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "dependencies": {
     "react": "^16.5.2",
-    "react-color": "^2.14.1",
     "react-dom": "^16.5.2",
-    "react-drag-list": "^1.1.0",
     "react-scripts": "2.0.4"
   },
   "scripts": {

--- a/src/App.css
+++ b/src/App.css
@@ -42,6 +42,7 @@ h2 {
 
 .column {
   flex: 1;
+  margin-bottom: 75px;
 }
 
 .quick-select {

--- a/src/App.css
+++ b/src/App.css
@@ -1,69 +1,69 @@
 html {
-    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, sans-serif;
-    box-sizing: border-box;
+  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, sans-serif;
+  box-sizing: border-box;
 }
 
 body {
-    background: #221e1f;
+  background: #221e1f;
 }
 
 h1 {
-    font-family: 'deutsch_gothicnormal', Arial, sans-serif;
-    font-size: 2.5em;
-    font-weight: bold;
-    letter-spacing: 0.1rem;
-    line-height: 0.5em;
-    margin: 0.8em 0;
-    color: #5f6061;
+  font-family: 'deutsch_gothicnormal', Arial, sans-serif;
+  font-size: 2.5em;
+  font-weight: bold;
+  letter-spacing: 0.1rem;
+  line-height: 0.5em;
+  margin: 0.8em 0;
+  color: #5f6061;
 }
 
 h2 {
-    font-family: 'deutsch_gothicnormal', Arial, sans-serif;
-    font-size: 1.5em;
-    font-weight: bold;
-    margin-bottom: 0.5em;
-    color: rgba(0, 0, 0, 0.3);
+  font-family: 'deutsch_gothicnormal', Arial, sans-serif;
+  font-size: 1.5em;
+  font-weight: bold;
+  margin-bottom: 0.5em;
+  color: rgba(0, 0, 0, 0.3);
 }
 
 .title {
-    font-size: 3em;
-    text-align: center;
+  font-size: 3em;
+  text-align: center;
 }
 
 .container {
-    width: 70%;
-    max-width: 960px;
-    margin: 0 auto;
-    margin-top: 75px;
-    display: flex;
-    align-content: center;
-    justify-content: center;
+  width: 70%;
+  max-width: 960px;
+  margin: 0 auto;
+  margin-top: 75px;
+  display: flex;
+  align-content: center;
+  justify-content: center;
 }
 
 .column {
-    flex: 1;
+  flex: 1;
 }
 
 .quick-select {
-    margin-bottom: 15px;
-    padding: 15px;
-    background: #ffffff;
-    border-radius: 4px;
+  margin-bottom: 15px;
+  padding: 15px;
+  background: #ffffff;
+  border-radius: 4px;
 }
 
 .buttons {
-    display: flex;
+  display: flex;
 }
 
-.buttons button {
-    background: #4caf50;
-    outline: 0;
-    border: 0;
-    border-radius: 4px;
-    padding: 10px;
-    margin-right: 10px;
-    font-size: 1em;
-    font-weight: bold;
-    color: #ffffff;
-    cursor: pointer;
+button {
+  background: #4caf50;
+  outline: 0;
+  border: 0;
+  border-radius: 4px;
+  padding: 10px;
+  margin-right: 10px;
+  font-size: 1em;
+  font-weight: bold;
+  color: #ffffff;
+  cursor: pointer;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -41,34 +41,34 @@ const spicyBoyz = [
 
 const deaconsDecoys = [
   {
-    color: 'rgb(148, 0, 211)',
     title: 'Eyrin',
     text: 'Elf Bard',
+    initiative: 3,
   },
   {
-    color: 'rgb(95, 194, 150)',
     title: 'Click',
     text: 'Kenku Cleric',
+    initiative: 1,
   },
   {
-    color: 'rgb(63, 81, 181)',
     title: 'Höf Dawndew',
     text: 'Half-Elf Monk',
+    initiative: 4,
   },
   {
-    color: 'rgb(240, 93, 5)',
     title: 'Har Dawndew',
     text: 'Half-Orc Barbarian',
+    initiative: 0,
   },
   {
-    color: 'rgb(255, 170, 0)',
     title: 'Trix',
     text: 'Tiefling Warlock',
+    initiative: 1,
   },
   {
-    color: 'rgb(0, 188, 212)',
     title: 'Fold',
     text: 'Human Warlock',
+    initiative: 1,
   },
 ];
 

--- a/src/App.js
+++ b/src/App.js
@@ -88,6 +88,7 @@ class App extends Component {
 
     this.addPlayer = this.addPlayer.bind(this);
     this.loadPlayers = this.loadPlayers.bind(this);
+    this.sortPlayers = this.sortPlayers.bind(this);
     this.updateInitiative = this.updateInitiative.bind(this);
   }
 
@@ -116,16 +117,32 @@ class App extends Component {
     });
   }
 
-  updateInitiative(initiative, player) {
-    console.log('Set ' + player.title + ' initiative to ' + initiative);
-    player.initiative = initiative;
-    const playerStateIndex = this.state.players.find(
-      item => item.title === player.title,
-    );
+  sortPlayers() {
+    // sort by value
+    let initiativeOrderArray = this.state.players.concat().sort(function(a, b) {
+      return b.initiative - a.initiative;
+    });
 
     this.setState({
-      playerStateIndex: player,
+      players: initiativeOrderArray,
     });
+  }
+
+  updateInitiative(initiative, player) {
+    console.log('Set ' + player.title + ' initiative to ' + initiative);
+
+    // Map the player array
+    const players = this.state.players.map(item => {
+      // If the item is the passed in player
+      if (item.title === player.title) {
+        // Update their initiative value
+        item.initiative = Number(initiative);
+      }
+      // Otherwise return as is
+      return item;
+    });
+
+    this.setState({ players });
   }
 
   render() {
@@ -139,6 +156,7 @@ class App extends Component {
             <h1>Initiative</h1>
             <List
               players={this.state.players}
+              handleSort={this.sortPlayers}
               handleInitiativeChange={this.updateInitiative}
             />
           </div>

--- a/src/App.js
+++ b/src/App.js
@@ -111,7 +111,15 @@ class App extends Component {
     }
 
     updateInitiative(initiative, player) {
-        // How do we pass the initiative value to the proper player object
+        console.log('Set ' + player.title + ' initiative to ' + initiative);
+        player.initiative = initiative;
+        const playerStateIndex = this.state.players.find(
+            item => item.title === player.title,
+        );
+
+        this.setState({
+            playerStateIndex: player,
+        });
     }
 
     render() {

--- a/src/App.js
+++ b/src/App.js
@@ -7,164 +7,162 @@ import List from './components/List/List';
 import Form from './components/Form/Form';
 
 const spicyBoyz = [
-    {
-        color: 'rgb(148, 0, 211)',
-        title: 'Caudemere Mornsworn',
-        text: 'Human Life Cleric',
-    },
-    {
-        color: 'rgb(95, 194, 150)',
-        title: 'Bjorr Eageraxe',
-        text: 'Dwarf Totem Barbarian',
-    },
-    {
-        color: 'rgb(63, 81, 181)',
-        title: 'Nixxe Ella Nackle',
-        text: 'Gnome Arcane Trickster Rogue',
-    },
-    {
-        color: 'rgb(240, 93, 5)',
-        title: 'Kaleus',
-        text: 'Warforged Evocation Wizard',
-    },
-    {
-        color: 'rgb(255, 170, 0)',
-        title: 'Monkin Lightfoot',
-        text: 'Halfling Swashbuckler Rogue',
-    },
-    {
-        color: 'rgb(0, 188, 212)',
-        title: 'Weerdarai Näilo',
-        text: 'Elf Gunslinger Fighter',
-    },
+  {
+    color: 'rgb(148, 0, 211)',
+    title: 'Caudemere Mornsworn',
+    text: 'Human Life Cleric',
+  },
+  {
+    color: 'rgb(95, 194, 150)',
+    title: 'Bjorr Eageraxe',
+    text: 'Dwarf Totem Barbarian',
+  },
+  {
+    color: 'rgb(63, 81, 181)',
+    title: 'Nixxe Ella Nackle',
+    text: 'Gnome Arcane Trickster Rogue',
+  },
+  {
+    color: 'rgb(240, 93, 5)',
+    title: 'Kaleus',
+    text: 'Warforged Evocation Wizard',
+  },
+  {
+    color: 'rgb(255, 170, 0)',
+    title: 'Monkin Lightfoot',
+    text: 'Halfling Swashbuckler Rogue',
+  },
+  {
+    color: 'rgb(0, 188, 212)',
+    title: 'Weerdarai Näilo',
+    text: 'Elf Gunslinger Fighter',
+  },
 ];
 
 const deaconsDecoys = [
-    {
-        title: 'Eyrin',
-        text: 'Elf Bard',
-        initiative: 3,
-    },
-    {
-        title: 'Click',
-        text: 'Kenku Cleric',
-        initiative: 1,
-    },
-    {
-        title: 'Höf Dawndew',
-        text: 'Half-Elf Monk',
-        initiative: 4,
-    },
-    {
-        title: 'Har Dawndew',
-        text: 'Half-Orc Barbarian',
-        initiative: 0,
-    },
-    {
-        title: 'Trix',
-        text: 'Tiefling Warlock',
-        initiative: 1,
-    },
-    {
-        title: 'Fold',
-        text: 'Human Warlock',
-        initiative: 1,
-    },
+  {
+    title: 'Eyrin',
+    text: 'Elf Bard',
+    initiative: 0,
+    dexterity: '+3',
+  },
+  {
+    title: 'Click',
+    text: 'Kenku Cleric',
+    initiative: 0,
+    dexterity: '+1',
+  },
+  {
+    title: 'Höf Dawndew',
+    text: 'Half-Elf Monk',
+    initiative: 0,
+    dexterity: '+3',
+  },
+  {
+    title: 'Har Dawndew',
+    text: 'Half-Orc Barbarian',
+    initiative: 0,
+    dexterity: '+0',
+  },
+  {
+    title: 'Trix',
+    text: 'Tiefling Warlock',
+    initiative: 0,
+    dexterity: '+0',
+  },
+  {
+    title: 'Fold',
+    text: 'Human Warlock',
+    initiative: 0,
+    dexterity: '+0',
+  },
 ];
 
 class App extends Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            players: deaconsDecoys,
-        };
+    this.state = {
+      players: deaconsDecoys,
+    };
 
-        this.addPlayer = this.addPlayer.bind(this);
-        this.loadPlayers = this.loadPlayers.bind(this);
-        this.updateInitiative = this.updateInitiative.bind(this);
+    this.addPlayer = this.addPlayer.bind(this);
+    this.loadPlayers = this.loadPlayers.bind(this);
+    this.updateInitiative = this.updateInitiative.bind(this);
+  }
+
+  addPlayer(player) {
+    this.setState({
+      players: [...this.state.players, player],
+    });
+  }
+
+  loadPlayers(event) {
+    // Loads a set of players based on button click
+    const target = event.target;
+    let players = [];
+
+    // Reading button text seems inefficient
+    if (target.innerText === 'Spicy Boyz') {
+      players = spicyBoyz;
+    } else if (target.innerText === "Deacon's Decoys") {
+      players = deaconsDecoys;
+    } else {
+      players = [];
     }
 
-    addPlayer(player) {
-        this.setState({
-            players: [...this.state.players, player],
-        });
-    }
+    this.setState({
+      players: players,
+    });
+  }
 
-    loadPlayers(event) {
-        // Loads a set of players based on button click
-        const target = event.target;
-        let players = [];
+  updateInitiative(initiative, player) {
+    console.log('Set ' + player.title + ' initiative to ' + initiative);
+    player.initiative = initiative;
+    const playerStateIndex = this.state.players.find(
+      item => item.title === player.title,
+    );
 
-        // Reading button text seems inefficient
-        if (target.innerText === 'Spicy Boyz') {
-            players = spicyBoyz;
-        } else if (target.innerText === "Deacon's Decoys") {
-            players = deaconsDecoys;
-        } else {
-            players = [];
-        }
+    this.setState({
+      playerStateIndex: player,
+    });
+  }
 
-        this.setState({
-            players: players,
-        });
-    }
+  render() {
+    return (
+      <div className="App">
+        <div className="title">
+          <h1>Grimoire</h1>
+        </div>
+        <div className="container">
+          <div className="column">
+            <h1>Initiative</h1>
+            <List
+              players={this.state.players}
+              handleInitiativeChange={this.updateInitiative}
+            />
+          </div>
+          <div className="column">
+            <h1>Add Character</h1>
+            <Form addPlayer={this.addPlayer} />
 
-    updateInitiative(initiative, player) {
-        console.log('Set ' + player.title + ' initiative to ' + initiative);
-        player.initiative = initiative;
-        const playerStateIndex = this.state.players.find(
-            item => item.title === player.title,
-        );
-
-        this.setState({
-            playerStateIndex: player,
-        });
-    }
-
-    render() {
-        return (
-            <div className="App">
-                <div className="title">
-                    <h1>Grimoire</h1>
-                </div>
-                <div className="container">
-                    <div className="column">
-                        <h1>Initiative</h1>
-                        <List
-                            players={this.state.players}
-                            handleInitiativeChange={this.updateInitiative}
-                        />
-                    </div>
-                    <div className="column">
-                        <h1>Add Character</h1>
-                        <Form addPlayer={this.addPlayer} />
-
-                        <div className="quick-select">
-                            <h2>Quick Select</h2>
-                            <div className="buttons">
-                                <button onClick={this.loadPlayers}>
-                                    Clear all
-                                </button>
-                                <button
-                                    onClick={this.loadPlayers}
-                                    value={spicyBoyz}
-                                >
-                                    Spicy Boyz
-                                </button>
-                                <button
-                                    onClick={this.loadPlayers}
-                                    value={deaconsDecoys}
-                                >
-                                    Deacon's Decoys
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <div className="quick-select">
+              <h2>Quick Select</h2>
+              <div className="buttons">
+                <button onClick={this.loadPlayers}>Clear all</button>
+                <button onClick={this.loadPlayers} value={spicyBoyz}>
+                  Spicy Boyz
+                </button>
+                <button onClick={this.loadPlayers} value={deaconsDecoys}>
+                  Deacon's Decoys
+                </button>
+              </div>
             </div>
-        );
-    }
+          </div>
+        </div>
+      </div>
+    );
+  }
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -7,140 +7,156 @@ import List from './components/List/List';
 import Form from './components/Form/Form';
 
 const spicyBoyz = [
-  {
-    color: 'rgb(148, 0, 211)',
-    title: 'Caudemere Mornsworn',
-    text: 'Human Life Cleric',
-  },
-  {
-    color: 'rgb(95, 194, 150)',
-    title: 'Bjorr Eageraxe',
-    text: 'Dwarf Totem Barbarian',
-  },
-  {
-    color: 'rgb(63, 81, 181)',
-    title: 'Nixxe Ella Nackle',
-    text: 'Gnome Arcane Trickster Rogue',
-  },
-  {
-    color: 'rgb(240, 93, 5)',
-    title: 'Kaleus',
-    text: 'Warforged Evocation Wizard',
-  },
-  {
-    color: 'rgb(255, 170, 0)',
-    title: 'Monkin Lightfoot',
-    text: 'Halfling Swashbuckler Rogue',
-  },
-  {
-    color: 'rgb(0, 188, 212)',
-    title: 'Weerdarai Näilo',
-    text: 'Elf Gunslinger Fighter',
-  },
+    {
+        color: 'rgb(148, 0, 211)',
+        title: 'Caudemere Mornsworn',
+        text: 'Human Life Cleric',
+    },
+    {
+        color: 'rgb(95, 194, 150)',
+        title: 'Bjorr Eageraxe',
+        text: 'Dwarf Totem Barbarian',
+    },
+    {
+        color: 'rgb(63, 81, 181)',
+        title: 'Nixxe Ella Nackle',
+        text: 'Gnome Arcane Trickster Rogue',
+    },
+    {
+        color: 'rgb(240, 93, 5)',
+        title: 'Kaleus',
+        text: 'Warforged Evocation Wizard',
+    },
+    {
+        color: 'rgb(255, 170, 0)',
+        title: 'Monkin Lightfoot',
+        text: 'Halfling Swashbuckler Rogue',
+    },
+    {
+        color: 'rgb(0, 188, 212)',
+        title: 'Weerdarai Näilo',
+        text: 'Elf Gunslinger Fighter',
+    },
 ];
 
 const deaconsDecoys = [
-  {
-    title: 'Eyrin',
-    text: 'Elf Bard',
-    initiative: 3,
-  },
-  {
-    title: 'Click',
-    text: 'Kenku Cleric',
-    initiative: 1,
-  },
-  {
-    title: 'Höf Dawndew',
-    text: 'Half-Elf Monk',
-    initiative: 4,
-  },
-  {
-    title: 'Har Dawndew',
-    text: 'Half-Orc Barbarian',
-    initiative: 0,
-  },
-  {
-    title: 'Trix',
-    text: 'Tiefling Warlock',
-    initiative: 1,
-  },
-  {
-    title: 'Fold',
-    text: 'Human Warlock',
-    initiative: 1,
-  },
+    {
+        title: 'Eyrin',
+        text: 'Elf Bard',
+        initiative: 3,
+    },
+    {
+        title: 'Click',
+        text: 'Kenku Cleric',
+        initiative: 1,
+    },
+    {
+        title: 'Höf Dawndew',
+        text: 'Half-Elf Monk',
+        initiative: 4,
+    },
+    {
+        title: 'Har Dawndew',
+        text: 'Half-Orc Barbarian',
+        initiative: 0,
+    },
+    {
+        title: 'Trix',
+        text: 'Tiefling Warlock',
+        initiative: 1,
+    },
+    {
+        title: 'Fold',
+        text: 'Human Warlock',
+        initiative: 1,
+    },
 ];
 
 class App extends Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.state = {
-      players: deaconsDecoys,
-    };
+        this.state = {
+            players: deaconsDecoys,
+        };
 
-    this.addPlayer = this.addPlayer.bind(this);
-    this.loadPlayers = this.loadPlayers.bind(this);
-  }
-
-  addPlayer(player) {
-    this.setState({
-      players: [...this.state.players, player],
-    });
-  }
-
-  loadPlayers(event) {
-    // Loads a set of players based on button click
-    const target = event.target;
-    let players = [];
-
-    // Reading button text seems inefficient
-    if (target.innerText === 'Spicy Boyz') {
-      players = spicyBoyz;
-    } else if (target.innerText === "Deacon's Decoys") {
-      players = deaconsDecoys;
-    } else {
-      players = [];
+        this.addPlayer = this.addPlayer.bind(this);
+        this.loadPlayers = this.loadPlayers.bind(this);
+        this.updateInitiative = this.updateInitiative.bind(this);
     }
 
-    this.setState({
-      players: players,
-    });
-  }
+    addPlayer(player) {
+        this.setState({
+            players: [...this.state.players, player],
+        });
+    }
 
-  render() {
-    return (
-      <div className="App">
-        <div className="title">
-          <h1>Grimoire</h1>
-        </div>
-        <div className="container">
-          <div className="column">
-            <h1>Initiative</h1>
-            <List players={this.state.players} />
-          </div>
-          <div className="column">
-            <h1>Add Character</h1>
-            <Form addPlayer={this.addPlayer} />
+    loadPlayers(event) {
+        // Loads a set of players based on button click
+        const target = event.target;
+        let players = [];
 
-            <div className="quick-select">
-              <h2>Quick Select</h2>
-              <div className="buttons">
-                <button onClick={this.loadPlayers}>Clear all</button>
-                <button onClick={this.loadPlayers} value={spicyBoyz}>
-                  Spicy Boyz
-                </button>
-                <button onClick={this.loadPlayers} value={deaconsDecoys}>
-                  Deacon's Decoys
-                </button>
-              </div>
+        // Reading button text seems inefficient
+        if (target.innerText === 'Spicy Boyz') {
+            players = spicyBoyz;
+        } else if (target.innerText === "Deacon's Decoys") {
+            players = deaconsDecoys;
+        } else {
+            players = [];
+        }
+
+        this.setState({
+            players: players,
+        });
+    }
+
+    updateInitiative(initiative, player) {
+        // How do we pass the initiative value to the proper player object
+    }
+
+    render() {
+        return (
+            <div className="App">
+                <div className="title">
+                    <h1>Grimoire</h1>
+                </div>
+                <div className="container">
+                    <div className="column">
+                        <h1>Initiative</h1>
+                        <List
+                            players={this.state.players}
+                            handleInitiativeChange={this.updateInitiative}
+                        />
+                    </div>
+                    <div className="column">
+                        <h1>Add Character</h1>
+                        <Form addPlayer={this.addPlayer} />
+
+                        <div className="quick-select">
+                            <h2>Quick Select</h2>
+                            <div className="buttons">
+                                <button onClick={this.loadPlayers}>
+                                    Clear all
+                                </button>
+                                <button
+                                    onClick={this.loadPlayers}
+                                    value={spicyBoyz}
+                                >
+                                    Spicy Boyz
+                                </button>
+                                <button
+                                    onClick={this.loadPlayers}
+                                    value={deaconsDecoys}
+                                >
+                                    Deacon's Decoys
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+        );
+    }
 }
 
 export default App;

--- a/src/components/Form/Form.css
+++ b/src/components/Form/Form.css
@@ -1,41 +1,41 @@
 .form {
-    margin-bottom: 15px;
-    padding: 15px;
-    background: #ffffff;
-    border-radius: 4px;
+  margin-bottom: 15px;
+  padding: 15px;
+  background: #ffffff;
+  border-radius: 4px;
 }
 
 label {
-    display: block;
-    margin-bottom: 15px;
+  display: block;
+  margin-bottom: 15px;
 }
 
 input {
-    outline: 0;
-    background: #f2f2f2;
-    width: 100%;
-    border: 0;
-    border-radius: 4px;
-    margin: 0 0 15px;
-    padding: 15px;
-    box-sizing: border-box;
-    font-size: 16px;
+  outline: 0;
+  background: #f2f2f2;
+  width: 100%;
+  border: 0;
+  border-radius: 4px;
+  margin: 0 0 15px;
+  padding: 15px;
+  box-sizing: border-box;
+  font-size: 16px;
 }
 
 .circle-picker {
-    margin: 5px;
-    padding-bottom: 15px;
+  margin: 5px;
+  padding-bottom: 15px;
 }
 
 .submit {
-    outline: 0;
-    background: #4caf50;
-    width: 100%;
-    border: 0;
-    border-radius: 4px;
-    padding: 15px;
-    font-size: 1.2em;
-    font-weight: bold;
-    color: #ffffff;
-    cursor: pointer;
+  outline: 0;
+  background: #4caf50;
+  width: 100%;
+  border: 0;
+  border-radius: 4px;
+  padding: 15px;
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #ffffff;
+  cursor: pointer;
 }

--- a/src/components/List/List.css
+++ b/src/components/List/List.css
@@ -17,3 +17,7 @@
 .player-title {
   color: #5f6061;
 }
+
+.player-initiative {
+  float: right;
+}

--- a/src/components/List/List.css
+++ b/src/components/List/List.css
@@ -20,4 +20,8 @@
 
 .player-initiative {
   float: right;
+  width: 60px;
+  position: relative;
+  right: 0;
+  top: -30px;
 }

--- a/src/components/List/List.css
+++ b/src/components/List/List.css
@@ -23,5 +23,5 @@
   width: 60px;
   position: relative;
   right: 0;
-  top: -30px;
+  top: -50px;
 }

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { sortBy } from 'lodash';
 
 import './List.css';
 

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -3,42 +3,49 @@ import React from 'react';
 import './List.css';
 
 class List extends React.Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.sortPlayers = this.sortPlayers.bind(this);
-  }
-  sortPlayers() {
-    // sort by value
-    let initiativeOrderArray = this.props.players.sort(function(a, b) {
-      return a.initiative - b.initiative;
-    });
+        this.sortPlayers = this.sortPlayers.bind(this);
+        this.handleInitiativeChange = this.handleInitiativeChange.bind(this);
+    }
 
-    this.setState({
-      deaconsDecoys: initiativeOrderArray.reverse(),
-    });
-  }
+    handleInitiativeChange(event) {
+        // How can we pass in the proper player
+        this.props.handleInitiativeChange(event.target.value, 'player');
+        this.sortPlayers();
+    }
 
-  render() {
-    return (
-      <div>
-        {this.props.players.map(function(record, index) {
-          return (
-            <div className="player-item" key={index}>
-              <div className="player-name">{record.title}</div>
-              <span className="player-title">{record.text}</span>
-              <input
-                className="player-initiative"
-                type="text"
-                placeholder={record.initiative}
-              />
+    sortPlayers() {
+        // sort by value
+        let initiativeOrderArray = this.props.players.sort(function(a, b) {
+            return a.initiative - b.initiative;
+        });
+
+        this.setState({
+            deaconsDecoys: initiativeOrderArray.reverse(),
+        });
+    }
+
+    render() {
+        return (
+            <div>
+                {this.props.players.map((record, index) => (
+                    <div className="player-item" key={index}>
+                        <div className="player-name">{record.title}</div>
+                        <span className="player-title">{record.text}</span>
+                        <input
+                            className="player-initiative"
+                            type="text"
+                            placeholder={record.initiative}
+                            onBlur={this.handleInitiativeChange}
+                        />
+                    </div>
+                ))}
+                <button onClick={this.sortPlayers}>Sort</button>
             </div>
-          );
-        })}
-        <button onClick={this.sortPlayers}>Sort</button>
-      </div>
-    );
-  }
+        );
+    }
 }
 
 export default List;

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -27,7 +27,11 @@ class List extends React.Component {
             <div className="player-item" key={index}>
               <div className="player-name">{record.title}</div>
               <span className="player-title">{record.text}</span>
-              <span className="player-initiative">{record.initiative}</span>
+              <input
+                className="player-initiative"
+                type="text"
+                placeholder={record.initiative}
+              />
             </div>
           );
         })}

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -6,8 +6,6 @@ import './List.css';
 class List extends React.Component {
   constructor(props) {
     super(props);
-
-    this.sortPlayers = this.sortPlayers.bind(this);
     this.handleInitiativeChange = this.handleInitiativeChange.bind(this);
   }
 
@@ -16,17 +14,6 @@ class List extends React.Component {
 
     this.props.handleInitiativeChange(initiative, player);
     event.preventDefault();
-  }
-
-  sortPlayers() {
-    // sort by value
-    let initiativeOrderArray = this.props.players.sort(function(a, b) {
-      return a.initiative - b.initiative;
-    });
-
-    this.setState({
-      deaconsDecoys: initiativeOrderArray.reverse(),
-    });
   }
 
   render() {
@@ -47,7 +34,7 @@ class List extends React.Component {
             </form>
           </div>
         ))}
-        <button onClick={this.sortPlayers}>Sort</button>
+        <button onClick={this.props.handleSort}>Sort</button>
       </div>
     );
   }

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,11 +1,14 @@
 import React from 'react';
 
-import ReactDragList from 'react-drag-list';
-import 'react-drag-list/assets/index.css';
-
 import './List.css';
 
 class List extends React.Component {
+  constructor(props) {
+    super(props);
+
+    console.log(this.props.players);
+  }
+
   _handleUpdate = (evt, updated) => {
     console.log(evt); // tslint:disable-line
     console.log(updated); // tslint:disable-line
@@ -21,20 +24,14 @@ class List extends React.Component {
   render() {
     return (
       <div className="simple">
-        <ReactDragList
-          dataSource={this.props.players}
-          rowKey="title"
-          row={(record, index) => (
-            <div key={index}>
+        {this.props.players.map(function(record, index) {
+          return (
+            <div className="player-item" key={index}>
               <div className="player-name">{record.title}</div>
               <span className="player-title">{record.text}</span>
             </div>
-          )}
-          handles={false}
-          className="player-list"
-          rowClassName="player-item"
-          onUpdate={this._handleUpdate}
-        />
+          );
+        })}
       </div>
     );
   }

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -6,32 +6,32 @@ class List extends React.Component {
   constructor(props) {
     super(props);
 
-    console.log(this.props.players);
+    this.sortPlayers = this.sortPlayers.bind(this);
   }
+  sortPlayers() {
+    // sort by value
+    let initiativeOrderArray = this.props.players.sort(function(a, b) {
+      return a.initiative - b.initiative;
+    });
 
-  _handleUpdate = (evt, updated) => {
-    console.log(evt); // tslint:disable-line
-    console.log(updated); // tslint:disable-line
-    // this.setState({
-    //   dataSource: [...updated, {
-    //     color: '#FFAA00',
-    //     title: 'Added Engineer',
-    //     text: 'Added Engineer',
-    //   }]
-    // })
-  };
+    this.setState({
+      deaconsDecoys: initiativeOrderArray.reverse(),
+    });
+  }
 
   render() {
     return (
-      <div className="simple">
+      <div>
         {this.props.players.map(function(record, index) {
           return (
             <div className="player-item" key={index}>
               <div className="player-name">{record.title}</div>
               <span className="player-title">{record.text}</span>
+              <span className="player-initiative">{record.initiative}</span>
             </div>
           );
         })}
+        <button onClick={this.sortPlayers}>Sort</button>
       </div>
     );
   }

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -3,57 +3,53 @@ import React from 'react';
 import './List.css';
 
 class List extends React.Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.sortPlayers = this.sortPlayers.bind(this);
-        this.handleInitiativeChange = this.handleInitiativeChange.bind(this);
-    }
+    this.sortPlayers = this.sortPlayers.bind(this);
+    this.handleInitiativeChange = this.handleInitiativeChange.bind(this);
+  }
 
-    handleInitiativeChange(event, player) {
-        let initiative = event.target.value;
-        if (initiative === '') {
-            return;
-        }
+  handleInitiativeChange(event, player) {
+    let initiative = event.target.value;
 
-        this.props.handleInitiativeChange(initiative, player);
-        this.sortPlayers();
-        // Find a way to reset the form values
-    }
+    this.props.handleInitiativeChange(initiative, player);
+    event.preventDefault();
+  }
 
-    sortPlayers() {
-        // sort by value
-        let initiativeOrderArray = this.props.players.sort(function(a, b) {
-            return a.initiative - b.initiative;
-        });
+  sortPlayers() {
+    // sort by value
+    let initiativeOrderArray = this.props.players.sort(function(a, b) {
+      return a.initiative - b.initiative;
+    });
 
-        this.setState({
-            deaconsDecoys: initiativeOrderArray.reverse(),
-        });
-    }
+    this.setState({
+      deaconsDecoys: initiativeOrderArray.reverse(),
+    });
+  }
 
-    render() {
-        return (
-            <div>
-                {this.props.players.map((player, index) => (
-                    <div className="player-item" key={index}>
-                        <div className="player-name">{player.title}</div>
-                        <span className="player-title">{player.text}</span>
-                        <input
-                            className="player-initiative"
-                            type="text"
-                            placeholder={player.initiative}
-                            defaultValue=""
-                            onBlur={event =>
-                                this.handleInitiativeChange(event, player)
-                            }
-                        />
-                    </div>
-                ))}
-                <button onClick={this.sortPlayers}>Sort</button>
-            </div>
-        );
-    }
+  render() {
+    return (
+      <div>
+        {this.props.players.map((player, index) => (
+          <div className="player-item" key={index}>
+            <div className="player-name">{player.title}</div>
+            <span className="player-title">{player.text}</span>
+            <form id="initiative">
+              <input
+                className="player-initiative"
+                type="text"
+                placeholder={player.dexterity}
+                value={player.initiative}
+                onChange={event => this.handleInitiativeChange(event, player)}
+              />
+            </form>
+          </div>
+        ))}
+        <button onClick={this.sortPlayers}>Sort</button>
+      </div>
+    );
+  }
 }
 
 export default List;

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -10,9 +10,8 @@ class List extends React.Component {
         this.handleInitiativeChange = this.handleInitiativeChange.bind(this);
     }
 
-    handleInitiativeChange(event) {
-        // How can we pass in the proper player
-        this.props.handleInitiativeChange(event.target.value, 'player');
+    handleInitiativeChange(event, player) {
+        this.props.handleInitiativeChange(event.target.value, player);
         this.sortPlayers();
     }
 
@@ -30,15 +29,17 @@ class List extends React.Component {
     render() {
         return (
             <div>
-                {this.props.players.map((record, index) => (
+                {this.props.players.map((player, index) => (
                     <div className="player-item" key={index}>
-                        <div className="player-name">{record.title}</div>
-                        <span className="player-title">{record.text}</span>
+                        <div className="player-name">{player.title}</div>
+                        <span className="player-title">{player.text}</span>
                         <input
                             className="player-initiative"
                             type="text"
-                            placeholder={record.initiative}
-                            onBlur={this.handleInitiativeChange}
+                            placeholder={player.initiative}
+                            onBlur={event =>
+                                this.handleInitiativeChange(event, player)
+                            }
                         />
                     </div>
                 ))}

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import './List.css';
 
@@ -11,8 +12,14 @@ class List extends React.Component {
     }
 
     handleInitiativeChange(event, player) {
-        this.props.handleInitiativeChange(event.target.value, player);
+        let initiative = event.target.value;
+        if (initiative === '') {
+            return;
+        }
+
+        this.props.handleInitiativeChange(initiative, player);
         this.sortPlayers();
+        // Find a way to reset the form values
     }
 
     sortPlayers() {
@@ -37,6 +44,7 @@ class List extends React.Component {
                             className="player-initiative"
                             type="text"
                             placeholder={player.initiative}
+                            defaultValue=""
                             onBlur={event =>
                                 this.handleInitiativeChange(event, player)
                             }

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { sortBy } from 'lodash';
 
 import './List.css';
 

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -8,6 +8,7 @@ class List extends React.Component {
 
     this.sortPlayers = this.sortPlayers.bind(this);
   }
+
   sortPlayers() {
     // sort by value
     let initiativeOrderArray = this.props.players.sort(function(a, b) {
@@ -22,19 +23,19 @@ class List extends React.Component {
   render() {
     return (
       <div>
-        {this.props.players.map(function(record, index) {
-          return (
-            <div className="player-item" key={index}>
-              <div className="player-name">{record.title}</div>
-              <span className="player-title">{record.text}</span>
-              <input
-                className="player-initiative"
-                type="text"
-                placeholder={record.initiative}
-              />
-            </div>
-          );
-        })}
+        {this.props.players.map((record, index) => (
+          <div className="player-item" key={index}>
+            <div className="player-name">{record.title}</div>
+            <span className="player-title">{record.text}</span>
+            <input
+              className="player-initiative"
+              type="text"
+              placeholder={record.initiative}
+              // Change to update the player object initative and sort
+              onBlur={this.sortPlayers}
+            />
+          </div>
+        ))}
         <button onClick={this.sortPlayers}>Sort</button>
       </div>
     );


### PR DESCRIPTION
This PR removes the drag and drop list style for a field and number based initiative order. It actually updates the state as a user types and re-renders the list in reverse order when the user clicks Sort.

It load Deacon's Decoys first but technically works for the Spicy Boyz and just assigns them to the Decoy state array. It works fine but not the most clean execution.

![screenshot_2018-10-15 take initiative](https://user-images.githubusercontent.com/1865372/46975861-be86a600-d095-11e8-8117-757314331423.png)
